### PR TITLE
Fix suboptimal CLX encoding

### DIFF
--- a/src/internal/clx_encode.cpp
+++ b/src/internal/clx_encode.cpp
@@ -73,8 +73,16 @@ void AppendClxPixelsOrFillRun(const uint8_t *src, unsigned length, std::vector<u
 		}
 		++src;
 	}
-	AppendClxPixelsRun(begin, prevColorBegin - begin, out);
-	AppendClxFillRun(prevColor, prevColorRunLength, out);
+
+	// Here we use 2 instead of `MinFillRunLength` because we know that this run
+	// is followed by transparent pixels.
+	// Width=2 Fill command takes 2 bytes, while the Pixels command is 3 bytes.
+	if (prevColorRunLength >= 2) {
+		AppendClxPixelsRun(begin, prevColorBegin - begin, out);
+		AppendClxFillRun(prevColor, prevColorRunLength, out);
+	} else {
+		AppendClxPixelsRun(begin, prevColorBegin - begin + prevColorRunLength, out);
+	}
 }
 
 } // namespace dvl_gfx


### PR DESCRIPTION
Previously we did not check the fill width after the end of the encoding loop, resulting in frequent width=1 Fill commands.

Before:

CLX sprite: 16x20 pixelDataSize=97b

command | width | bytes | color(s)
--------|------:|------:|---------
Transp. |    80 |     1 |
Pixels  |     2 |     3 | 203 199
Fill    |     3 |     2 | 202
Pixels  |     2 |     3 | 199 201
Fill    |     1 |     2 | 205
Transp. |     8 |     1 |
Pixels  |     3 |     4 | 205 199 196
Fill    |     4 |     2 | 197
Fill    |     1 |     2 | 202
Transp. |     9 |     1 |
Pixels  |     6 |     7 | 206 199 197 203 206 202
Fill    |     1 |     2 | 204
Transp. |    10 |     1 |
Pixels  |     4 |     5 | 206 199 197 205
Fill    |     1 |     2 | 207
Transp. |    12 |     1 |
Pixels  |     3 |     4 | 206 197 197
Fill    |     1 |     2 | 205
Transp. |     9 |     1 |
Pixels  |     7 |     8 | 207 205 203 206 206 197 197
Fill    |     1 |     2 | 206
Transp. |     8 |     1 |
Pixels  |     3 |     4 | 204 197 199
Fill    |     1 |     2 | 205
Transp. |     1 |     1 |
Pixels  |     2 |     3 | 202 197
Fill    |     1 |     2 | 204
Transp. |     8 |     1 |
Pixels  |     7 |     8 | 206 197 199 207 206 199 196
Fill    |     1 |     2 | 205
Transp. |     9 |     1 |
Pixels  |     1 |     2 | 203
Fill    |     4 |     2 | 197
Fill    |     1 |     2 | 202
Transp. |    10 |     1 |
Pixels  |     5 |     6 | 207 205 199 199 203
Fill    |     1 |     2 | 207
Transp. |    89 |     1 |

After:

CLX sprite: 16x20 pixelDataSize=88b

command | width | bytes | color(s)
--------|------:|------:|---------
Transp. |    80 |     1 |
Pixels  |     2 |     3 | 203 199
Fill    |     3 |     2 | 202
Pixels  |     3 |     4 | 199 201 205
Transp. |     8 |     1 |
Pixels  |     3 |     4 | 205 199 196
Fill    |     4 |     2 | 197
Pixels  |     1 |     2 | 202
Transp. |     9 |     1 |
Pixels  |     7 |     8 | 206 199 197 203 206 202 204
Transp. |    10 |     1 |
Pixels  |     5 |     6 | 206 199 197 205 207
Transp. |    12 |     1 |
Pixels  |     4 |     5 | 206 197 197 205
Transp. |     9 |     1 |
Pixels  |     8 |     9 | 207 205 203 206 206 197 197 206
Transp. |     8 |     1 |
Pixels  |     4 |     5 | 204 197 199 205
Transp. |     1 |     1 |
Pixels  |     3 |     4 | 202 197 204
Transp. |     8 |     1 |
Pixels  |     8 |     9 | 206 197 199 207 206 199 196 205
Transp. |     9 |     1 |
Pixels  |     1 |     2 | 203
Fill    |     4 |     2 | 197
Pixels  |     1 |     2 | 202
Transp. |    10 |     1 |
Pixels  |     6 |     7 | 207 205 199 199 203 207
Transp. |    89 |     1 |