### PR TITLE
Re-encode CL2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ add_library(
 )
 add_library(DvlGfx::cl22clx ALIAS cl22clx)
 target_link_libraries(cl22clx PUBLIC common)
-target_link_libraries(cel2clx PRIVATE clx_encode)
+target_link_libraries(cl22clx PRIVATE clx_encode)
 set_target_properties(cl22clx PROPERTIES PUBLIC_HEADER "src/public/include/cl22clx.hpp")
 target_include_directories(cl22clx PRIVATE src/internal)
 

--- a/src/internal/cel2clx.cpp
+++ b/src/internal/cel2clx.cpp
@@ -62,16 +62,16 @@ std::optional<IoError> CelToClx(const uint8_t *data, size_t size,
 			WriteLE32(&clxData[4 * group], clxData.size());
 		}
 
-		// CL2 header: frame count, frame offset for each frame, file size
-		const size_t cl2DataOffset = clxData.size();
+		// CLX header: frame count, frame offset for each frame, file size
+		const size_t clxDataOffset = clxData.size();
 		clxData.resize(clxData.size() + 4 * (2 + static_cast<size_t>(numFrames)));
-		WriteLE32(&clxData[cl2DataOffset], numFrames);
+		WriteLE32(&clxData[clxDataOffset], numFrames);
 
 		const uint8_t *srcEnd = &data[LoadLE32(&data[4])];
 		for (size_t frame = 1; frame <= numFrames; ++frame) {
 			const uint8_t *src = srcEnd;
 			srcEnd = &data[LoadLE32(&data[4 * (frame + 1)])];
-			WriteLE32(&clxData[cl2DataOffset + 4 * frame], static_cast<uint32_t>(clxData.size() - cl2DataOffset));
+			WriteLE32(&clxData[clxDataOffset + 4 * frame], static_cast<uint32_t>(clxData.size() - clxDataOffset));
 
 			// Skip CEL frame header if there is one.
 			constexpr size_t CelFrameHeaderSize = 10;
@@ -107,12 +107,12 @@ std::optional<IoError> CelToClx(const uint8_t *data, size_t size,
 				}
 				++frameHeight;
 			}
+			AppendClxTransparentRun(transparentRunWidth, clxData);
 			WriteLE16(&clxData[frameHeaderPos + 4], frameHeight);
 			memset(&clxData[frameHeaderPos + 6], 0, 4);
-			AppendClxTransparentRun(transparentRunWidth, clxData);
 		}
 
-		WriteLE32(&clxData[cl2DataOffset + 4 * (1 + static_cast<size_t>(numFrames))], static_cast<uint32_t>(clxData.size() - cl2DataOffset));
+		WriteLE32(&clxData[clxDataOffset + 4 * (1 + static_cast<size_t>(numFrames))], static_cast<uint32_t>(clxData.size() - clxDataOffset));
 		data = srcEnd;
 	}
 	return std::nullopt;

--- a/src/public/include/cl22clx.hpp
+++ b/src/public/include/cl22clx.hpp
@@ -12,7 +12,10 @@
 namespace dvl_gfx {
 
 /**
- * @brief Converts a CL2 image to CLX in-place.
+ * @brief Converts a CL2 image to CLX.
+ *
+ * Re-encodes the frames. This can reduce file size because the dvl_gfx encoder
+ * is more optimal than the original encoder used by Blizzard.
  *
  * @param data The CL2 buffer.
  * @param size CL2 buffer size.
@@ -20,16 +23,30 @@ namespace dvl_gfx {
  * @param numWidths The number of widths.
  * @return std::optional<IoError>
  */
-std::optional<IoError> Cl2ToClx(uint8_t *data, size_t size,
+std::optional<IoError> Cl2ToClx(const uint8_t *data, size_t size,
+    const uint16_t *widths, size_t numWidths, std::vector<uint8_t> &out);
+
+/**
+ * @brief Converts a CL2 image to CLX in-place without re-encoding.
+ *
+ * Does not re-encode the frames.
+ *
+ * @param data The CL2 buffer.
+ * @param size CL2 buffer size.
+ * @param widths Widths of each frame. If all the frame are the same width, this can be a single number.
+ * @param numWidths The number of widths.
+ * @return std::optional<IoError>
+ */
+std::optional<IoError> Cl2ToClxNoReencode(uint8_t *data, size_t size,
     const uint16_t *widths, size_t numWidths);
 
 std::optional<IoError> Cl2ToClx(const char *inputPath, const char *outputPath,
-    const uint16_t *widths, size_t numWidths);
+    const uint16_t *widths, size_t numWidths, bool reencode = true);
 
 inline std::optional<IoError> Cl2ToClx(const char *inputPath, const char *outputPath,
-    const std::vector<uint16_t> &widths)
+    const std::vector<uint16_t> &widths, bool reencode = true)
 {
-	return Cl2ToClx(inputPath, outputPath, widths.data(), widths.size());
+	return Cl2ToClx(inputPath, outputPath, widths.data(), widths.size(), reencode);
 }
 
 /**
@@ -38,11 +55,12 @@ inline std::optional<IoError> Cl2ToClx(const char *inputPath, const char *output
  * @param inputPaths Paths to the input files.
  * @param numFiles The number of `inputPaths`.
  * @param widths Widths of each frame. If all the frame are the same width, this can be a single number.
+ * @param reencode If true, reencodes the CL2 graphics data (our encoder produces slightly smaller files).
  * @return std::optional<IoError>
  */
 std::optional<IoError> CombineCl2AsClxSheet(
     const char *const *inputPaths, size_t numFiles, const char *outputPath,
-    const std::vector<uint16_t> &widths);
+    const std::vector<uint16_t> &widths, bool reencode = true);
 
 } // namespace dvl_gfx
 #endif // DVL_GFX_CL22CLX_H_


### PR DESCRIPTION
Original Blizzard encoder is slightly less optimal than our encoder.

Savings for unpacked and minified MPQs:
* diabdat.mpq: 918,311 bytes.
* hellfire.mpq: 313,882 bytes.

Example player graphics (note that only a few are loaded at any given time for single player):
* diabdat/plrgfx/warrior/: 366,564 bytes.

Example monster graphics:

* diabdat/monsters/skelbow: 5,391 bytes.

Fixes #5